### PR TITLE
Install the Python development packages

### DIFF
--- a/manylinux2014/aarch64/Dockerfile
+++ b/manylinux2014/aarch64/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/manylinux2014/armv7l/Dockerfile
+++ b/manylinux2014/armv7l/Dockerfile
@@ -120,11 +120,11 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 RUN mkdir -p /opt/python

--- a/manylinux2014/i686/Dockerfile
+++ b/manylinux2014/i686/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/manylinux2014/ppc64/Dockerfile
+++ b/manylinux2014/ppc64/Dockerfile
@@ -120,11 +120,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 RUN mkdir -p /opt/python

--- a/manylinux2014/ppc64le/Dockerfile
+++ b/manylinux2014/ppc64le/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/manylinux2014/s390x/Dockerfile
+++ b/manylinux2014/s390x/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/manylinux2014/x86_64/Dockerfile
+++ b/manylinux2014/x86_64/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/manylinux_2_24/aarch64/Dockerfile
+++ b/manylinux_2_24/aarch64/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/manylinux_2_24/armv7l/Dockerfile
+++ b/manylinux_2_24/armv7l/Dockerfile
@@ -120,11 +120,11 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 RUN mkdir -p /opt/python

--- a/manylinux_2_24/i686/Dockerfile
+++ b/manylinux_2_24/i686/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/manylinux_2_24/ppc64le/Dockerfile
+++ b/manylinux_2_24/ppc64le/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/manylinux_2_24/s390x/Dockerfile
+++ b/manylinux_2_24/s390x/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/manylinux_2_24/x86_64/Dockerfile
+++ b/manylinux_2_24/x86_64/Dockerfile
@@ -122,11 +122,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=manylinux /opt/_internal /opt/_internal

--- a/musllinux_1_2/aarch64/Dockerfile
+++ b/musllinux_1_2/aarch64/Dockerfile
@@ -20,11 +20,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=musllinux /opt/_internal /opt/_internal

--- a/musllinux_1_2/armv7l/Dockerfile
+++ b/musllinux_1_2/armv7l/Dockerfile
@@ -18,11 +18,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 # Target openssl & libffi

--- a/musllinux_1_2/i686/Dockerfile
+++ b/musllinux_1_2/i686/Dockerfile
@@ -20,11 +20,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=musllinux /opt/_internal /opt/_internal

--- a/musllinux_1_2/x86_64/Dockerfile
+++ b/musllinux_1_2/x86_64/Dockerfile
@@ -20,11 +20,11 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     add-apt-repository -y ppa:pypy/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.6 python3.6-venv \
-    python3.7 python3.7-venv \
-    python3.9 python3.9-venv \
-    python3.10 python3.10-venv \
-    python3 python3-pip python3-venv python-is-python3 \
+    python3.6 python3.6-venv python3.6-dev \
+    python3.7 python3.7-venv python3.7-dev \
+    python3.9 python3.9-venv python3.9-dev \
+    python3.10 python3.10-venv python3.10-dev \
+    python3 python3-pip python3-venv python3-dev python-is-python3 \
     pypy3
 
 COPY --from=musllinux /opt/_internal /opt/_internal


### PR DESCRIPTION
The Python development packages are required to build C
extensions (e.g. with Cython). Make them available in all
Docker images.

This commit has been created with this one-liner:

```
find . -iname Dockerfile -print0 | xargs -0 -n1 -- perl -i -pe 's/python([\.\d]+)-venv/python\1-venv python\1-dev/g'
```