### PR TITLE
Drop support for python 3.7 and 3.8

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -224,9 +224,9 @@ jobs:
           docker run --rm ghcr.io/${{ github.repository_owner }}/${{ matrix.platform.manylinux }}-cross:${{ matrix.platform.arch }}-${{ matrix.os.arch }} \
             bash -c 'pip3 --version'
           docker run --rm ghcr.io/${{ github.repository_owner }}/${{ matrix.platform.manylinux }}-cross:${{ matrix.platform.arch }}-${{ matrix.os.arch }} \
-            bash -c 'for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do "python$VER" -m pip --version || exit 1; done'
+            bash -c 'for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do "python$VER" -m pip --version || exit 1; done'
           docker run --rm ghcr.io/${{ github.repository_owner }}/${{ matrix.platform.manylinux }}-cross:${{ matrix.platform.arch }}-${{ matrix.os.arch }} \
-            bash -c 'for VER in 3.7 3.8 3.9 3.10; do "pypy$VER" -m pip --version || exit 1; done'
+            bash -c 'for VER in 3.9 3.10; do "pypy$VER" -m pip --version || exit 1; done'
       - name: Build and push multiarch image
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -11,8 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         python: [
-          { version: '3.7', abi: 'cp37-cp37m' },
-          { version: '3.8', abi: 'cp38-cp38' },
           { version: '3.9', abi: 'cp39-cp39' },
           { version: '3.10', abi: 'cp310-cp310' },
         ]
@@ -58,10 +56,10 @@ jobs:
             apt-get install -y --no-install-recommends python3 python3-distutils software-properties-common curl
             add-apt-repository ppa:deadsnakes/ppa
             apt-get update
-            apt-get install -y python3.7 python3.7-distutils python3.9 python3.9-distutils python3.10 python3.10-distutils
-            for VER in 3.7 3.8 3.9 3.10; do curl -sS https://bootstrap.pypa.io/get-pip.py | "python$VER"; done
+            apt-get install -y python3.9 python3.9-distutils python3.10 python3.10-distutils
+            for VER in 3.9 3.10; do curl -sS https://bootstrap.pypa.io/get-pip.py | "python$VER"; done
           run: |
-            for VER in 3.7 3.8 3.9 3.10; do
+            for VER in 3.9 3.10; do
               PYTHON="python$VER"
               $PYTHON -m pip install pyo3-test --no-index --find-links /io --force-reinstall
               $PYTHON -c 'import pyo3_test; assert pyo3_test.fourtytwo == 42'
@@ -74,8 +72,6 @@ jobs:
     strategy:
       matrix:
         python: [
-          { version: '3.7', name: 'cp37-cp37m' },
-          { version: '3.8', name: 'cp38-cp38' },
           { version: '3.9', name: 'cp39-cp39' },
           { version: '3.10', name: 'cp310-cp310' },
         ]
@@ -147,10 +143,10 @@ jobs:
             apt-get install -y --no-install-recommends python3 python3-distutils software-properties-common curl
             add-apt-repository ppa:deadsnakes/ppa
             apt-get update
-            apt-get install -y python3.7 python3.7-distutils python3.9 python3.9-distutils python3.10 python3.10-distutils
-            for VER in 3.7 3.8 3.9 3.10; do curl -sS https://bootstrap.pypa.io/get-pip.py | "python$VER"; done
+            apt-get install -y python3.9 python3.9-distutils python3.10 python3.10-distutils
+            for VER in 3.9 3.10; do curl -sS https://bootstrap.pypa.io/get-pip.py | "python$VER"; done
           run: |
-            for VER in 3.7 3.8 3.9 3.10; do
+            for VER in 3.9 3.10; do
               PYTHON="python$VER"
               $PYTHON -m pip install pyo3-test --no-index --find-links /io --force-reinstall
               $PYTHON -c 'import pyo3_test; assert pyo3_test.fourtytwo == 42'

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -123,8 +123,6 @@ ENV {{ target | replace('ibm', 'unknown') | replace('-', '_') | upper }}_OPENSSL
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -133,12 +131,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -154,50 +146,6 @@ COPY --from=musllinux /opt/python /opt/python
 {% else %}
 {% set python_target = "armv7l-unknown-linux-gnueabihf" if target.startswith("armv7-") else target %}
 RUN mkdir -p /opt/python
-
-RUN cd /tmp && \
-    VERS=3.7.17 && PREFIX=/opt/python/cp37-cp37m && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    {% if target.startswith('loongarch64-') -%}
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub' && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess' && \
-    curl -sL https://github.com/astral-sh/python-build-standalone/raw/8138f8f7337d95bd098b398d368d4763861f2395/cpython-unix/patch-configure-add-loongarch-triplet.patch | patch -p1 && \
-    {% endif -%}
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host={{ python_target }} --target={{ python_target }} --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-{{ 'linux-gnu' if platform.startswith('manylinux') else 'linux-musl' }} --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    {% if target.startswith('armv7-') -%}
-    sed -i 's/_PYTHON_HOST_PLATFORM=linux-arm/_PYTHON_HOST_PLATFORM=linux-armv7l/' Makefile && \
-    {% endif -%}
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-
-RUN cd /tmp && \
-    VERS=3.8.20 && PREFIX=/opt/python/cp38-cp38 && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    {% if target.startswith('loongarch64-') -%}
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub' && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess' && \
-    curl -sL https://github.com/astral-sh/python-build-standalone/raw/8138f8f7337d95bd098b398d368d4763861f2395/cpython-unix/patch-configure-add-loongarch-triplet.patch | patch -p1 && \
-    {% endif -%}
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host={{ python_target }} --target={{ python_target }} --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-{{ 'linux-gnu' if platform.startswith('manylinux') else 'linux-musl' }} --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    {% if target.startswith('armv7-') -%}
-    sed -i 's/_PYTHON_HOST_PLATFORM=linux-arm/_PYTHON_HOST_PLATFORM=linux-armv7l/' Makefile && \
-    {% endif -%}
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 RUN cd /tmp && \
     VERS=3.9.25 && PREFIX=/opt/python/cp39-cp39 && \
@@ -310,9 +258,9 @@ RUN cd /tmp && \
     # We do not need precompiled .pyc and .pyo files.
     find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 {%- endif %}
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Docker image repository: [messense/manylinux2014-cross], based on Ubuntu 22.04 w
 
 | Architecture |      Tag        |          Target Python                     |       Host Python      |
 | ------------ | --------------- | ------------------------------------------ | ---------------------- |
-| x86_64       | x86_64          | Copied from manylinux2014_x86_64           | Python 3.7 - 3.14      |
-| i686         | i686            | Copied from manylinux2014_i686             | Python 3.7 - 3.14      |
-| aarch64      | aarch64         | Copied from manylinux2014_aarch64          | Python 3.7 - 3.14      |
-| armv7l       | armv7l / armv7  | `/opt/python/cp3[7-13]`, built from source | Python 3.7 - 3.14      |
-| s390x        | s390x           | Copied from manylinux2014_s390x            | Python 3.7 - 3.14      |
-| ppc64        | ppc64           | `/opt/python/cp3[7-13]`, built from source | Python 3.7 - 3.14      |
-| ppc64le      | ppc64le         | Copied from manylinux2014_ppc64le          | Python 3.7 - 3.14      |
+| x86_64       | x86_64          | Copied from manylinux2014_x86_64           | Python 3.9 - 3.14      |
+| i686         | i686            | Copied from manylinux2014_i686             | Python 3.9 - 3.14      |
+| aarch64      | aarch64         | Copied from manylinux2014_aarch64          | Python 3.9 - 3.14      |
+| armv7l       | armv7l / armv7  | `/opt/python/cp3[9-13]`, built from source | Python 3.9 - 3.14      |
+| s390x        | s390x           | Copied from manylinux2014_s390x            | Python 3.9 - 3.14      |
+| ppc64        | ppc64           | `/opt/python/cp3[9-13]`, built from source | Python 3.9 - 3.14      |
+| ppc64le      | ppc64le         | Copied from manylinux2014_ppc64le          | Python 3.9 - 3.14      |
 
 ## manylinux_2_28
 
@@ -30,11 +30,11 @@ Docker image repository: [messense/manylinux_2_28-cross], based on Ubuntu 22.04 
 
 | Architecture |      Tag        |          Target Python                     |       Host Python      |
 | ------------ | --------------- | ------------------------------------------ | ---------------------- |
-| x86_64       | x86_64          | Copied from manylinux_2_28_x86_64          | Python 3.7 - 3.14      |
-| aarch64      | aarch64         | Copied from manylinux_2_28_aarch64         | Python 3.7 - 3.14      |
-| armv7l       | armv7l / armv7  | `/opt/python/cp3[7-13]`, built from source | Python 3.7 - 3.14      |
-| s390x        | s390x           | `/opt/python/cp3[7-13]`, built from source | Python 3.7 - 3.14      |
-| ppc64le      | ppc64le         | `/opt/python/cp3[7-13]`, built from source | Python 3.7 - 3.14      |
+| x86_64       | x86_64          | Copied from manylinux_2_28_x86_64          | Python 3.9 - 3.14      |
+| aarch64      | aarch64         | Copied from manylinux_2_28_aarch64         | Python 3.9 - 3.14      |
+| armv7l       | armv7l / armv7  | `/opt/python/cp3[9-13]`, built from source | Python 3.9 - 3.14      |
+| s390x        | s390x           | `/opt/python/cp3[9-13]`, built from source | Python 3.9 - 3.14      |
+| ppc64le      | ppc64le         | `/opt/python/cp3[9-13]`, built from source | Python 3.9 - 3.14      |
 
 ## manylinux_2_31
 
@@ -42,7 +42,7 @@ Docker image repository: [messense/manylinux_2_31-cross], based on Ubuntu 22.04 
 
 | Architecture |      Tag        |          Target Python                     |       Host Python      |
 | ------------ | --------------- | ------------------------------------------ | ---------------------- |
-| riscv64      | riscv64         | `/opt/python/cp3[7-13]`, built from source | Python 3.7 - 3.14      |
+| riscv64      | riscv64         | `/opt/python/cp3[9-13]`, built from source | Python 3.9 - 3.14      |
 
 ## manylinux_2_36
 
@@ -50,7 +50,7 @@ Docker image repository: [messense/manylinux_2_36-cross], based on Ubuntu 22.04 
 
 | Architecture |      Tag        |          Target Python                     |       Host Python      |
 | ------------ | --------------- | ------------------------------------------ | ---------------------- |
-| loongarch64  | loongarch64     | `/opt/python/cp3[7-13]`, built from source | Python 3.7 - 3.14      |
+| loongarch64  | loongarch64     | `/opt/python/cp3[9-13]`, built from source | Python 3.9 - 3.14      |
 
 ## manylinux_2_39
 
@@ -58,7 +58,7 @@ Docker image repository: [messense/manylinux_2_39-cross], based on Ubuntu 22.04 
 
 | Architecture |      Tag        |          Target Python                     |       Host Python      |
 | ------------ | --------------- | ------------------------------------------ | ---------------------- |
-| riscv64      | riscv64         | Copied from manylinux_2_39_riscv64         | Python 3.7 - 3.14      |
+| riscv64      | riscv64         | Copied from manylinux_2_39_riscv64         | Python 3.9 - 3.14      |
 
 ## Environment variables
 

--- a/manylinux2014/aarch64/Dockerfile
+++ b/manylinux2014/aarch64/Dockerfile
@@ -105,8 +105,6 @@ ENV AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/aarch64-unknown-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -115,12 +113,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -131,9 +123,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=manylinux /opt/_internal /opt/_internal
 COPY --from=manylinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux2014/armv7l/Dockerfile
+++ b/manylinux2014/armv7l/Dockerfile
@@ -104,8 +104,6 @@ ENV ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_DIR=/usr/armv7-unknown-linux-gnueabihf
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -114,12 +112,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -129,36 +121,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 
 
 RUN mkdir -p /opt/python
-
-RUN cd /tmp && \
-    VERS=3.7.17 && PREFIX=/opt/python/cp37-cp37m && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=armv7l-unknown-linux-gnueabihf --target=armv7l-unknown-linux-gnueabihf --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    sed -i 's/_PYTHON_HOST_PLATFORM=linux-arm/_PYTHON_HOST_PLATFORM=linux-armv7l/' Makefile && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-
-RUN cd /tmp && \
-    VERS=3.8.20 && PREFIX=/opt/python/cp38-cp38 && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=armv7l-unknown-linux-gnueabihf --target=armv7l-unknown-linux-gnueabihf --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    sed -i 's/_PYTHON_HOST_PLATFORM=linux-arm/_PYTHON_HOST_PLATFORM=linux-armv7l/' Makefile && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 RUN cd /tmp && \
     VERS=3.9.25 && PREFIX=/opt/python/cp39-cp39 && \
@@ -249,9 +211,9 @@ RUN cd /tmp && \
     find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
     # We do not need precompiled .pyc and .pyo files.
     find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux2014/i686/Dockerfile
+++ b/manylinux2014/i686/Dockerfile
@@ -105,8 +105,6 @@ ENV I686_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/i686-unknown-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -115,12 +113,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -131,9 +123,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=manylinux /opt/_internal /opt/_internal
 COPY --from=manylinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux2014/ppc64/Dockerfile
+++ b/manylinux2014/ppc64/Dockerfile
@@ -104,8 +104,6 @@ ENV POWERPC64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/powerpc64-unknown-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -114,12 +112,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -129,34 +121,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 
 
 RUN mkdir -p /opt/python
-
-RUN cd /tmp && \
-    VERS=3.7.17 && PREFIX=/opt/python/cp37-cp37m && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=powerpc64-unknown-linux-gnu --target=powerpc64-unknown-linux-gnu --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-
-RUN cd /tmp && \
-    VERS=3.8.20 && PREFIX=/opt/python/cp38-cp38 && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=powerpc64-unknown-linux-gnu --target=powerpc64-unknown-linux-gnu --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 RUN cd /tmp && \
     VERS=3.9.25 && PREFIX=/opt/python/cp39-cp39 && \
@@ -241,9 +205,9 @@ RUN cd /tmp && \
     find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
     # We do not need precompiled .pyc and .pyo files.
     find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux2014/ppc64le/Dockerfile
+++ b/manylinux2014/ppc64le/Dockerfile
@@ -105,8 +105,6 @@ ENV POWERPC64LE_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/powerpc64le-unknown-linux-gnu
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -115,12 +113,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -131,9 +123,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=manylinux /opt/_internal /opt/_internal
 COPY --from=manylinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux2014/s390x/Dockerfile
+++ b/manylinux2014/s390x/Dockerfile
@@ -105,8 +105,6 @@ ENV S390X_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/s390x-ibm-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -115,12 +113,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -131,9 +123,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=manylinux /opt/_internal /opt/_internal
 COPY --from=manylinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux2014/x86_64/Dockerfile
+++ b/manylinux2014/x86_64/Dockerfile
@@ -105,8 +105,6 @@ ENV X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/x86_64-unknown-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -115,12 +113,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -131,9 +123,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=manylinux /opt/_internal /opt/_internal
 COPY --from=manylinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux_2_28/aarch64/Dockerfile
+++ b/manylinux_2_28/aarch64/Dockerfile
@@ -105,8 +105,6 @@ ENV AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/aarch64-unknown-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -115,12 +113,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -131,9 +123,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=manylinux /opt/_internal /opt/_internal
 COPY --from=manylinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux_2_28/armv7l/Dockerfile
+++ b/manylinux_2_28/armv7l/Dockerfile
@@ -104,8 +104,6 @@ ENV ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_DIR=/usr/armv7-unknown-linux-gnueabihf
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -114,12 +112,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -129,36 +121,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 
 
 RUN mkdir -p /opt/python
-
-RUN cd /tmp && \
-    VERS=3.7.17 && PREFIX=/opt/python/cp37-cp37m && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=armv7l-unknown-linux-gnueabihf --target=armv7l-unknown-linux-gnueabihf --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    sed -i 's/_PYTHON_HOST_PLATFORM=linux-arm/_PYTHON_HOST_PLATFORM=linux-armv7l/' Makefile && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-
-RUN cd /tmp && \
-    VERS=3.8.20 && PREFIX=/opt/python/cp38-cp38 && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=armv7l-unknown-linux-gnueabihf --target=armv7l-unknown-linux-gnueabihf --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    sed -i 's/_PYTHON_HOST_PLATFORM=linux-arm/_PYTHON_HOST_PLATFORM=linux-armv7l/' Makefile && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 RUN cd /tmp && \
     VERS=3.9.25 && PREFIX=/opt/python/cp39-cp39 && \
@@ -249,9 +211,9 @@ RUN cd /tmp && \
     find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
     # We do not need precompiled .pyc and .pyo files.
     find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux_2_28/ppc64le/Dockerfile
+++ b/manylinux_2_28/ppc64le/Dockerfile
@@ -105,8 +105,6 @@ ENV POWERPC64LE_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/powerpc64le-unknown-linux-gnu
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -115,12 +113,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -131,9 +123,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=manylinux /opt/_internal /opt/_internal
 COPY --from=manylinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux_2_28/s390x/Dockerfile
+++ b/manylinux_2_28/s390x/Dockerfile
@@ -104,8 +104,6 @@ ENV S390X_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/s390x-ibm-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -114,12 +112,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -129,34 +121,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 
 
 RUN mkdir -p /opt/python
-
-RUN cd /tmp && \
-    VERS=3.7.17 && PREFIX=/opt/python/cp37-cp37m && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=s390x-ibm-linux-gnu --target=s390x-ibm-linux-gnu --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-
-RUN cd /tmp && \
-    VERS=3.8.20 && PREFIX=/opt/python/cp38-cp38 && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=s390x-ibm-linux-gnu --target=s390x-ibm-linux-gnu --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 RUN cd /tmp && \
     VERS=3.9.25 && PREFIX=/opt/python/cp39-cp39 && \
@@ -241,9 +205,9 @@ RUN cd /tmp && \
     find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
     # We do not need precompiled .pyc and .pyo files.
     find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux_2_28/x86_64/Dockerfile
+++ b/manylinux_2_28/x86_64/Dockerfile
@@ -105,8 +105,6 @@ ENV X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/x86_64-unknown-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -115,12 +113,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -131,9 +123,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=manylinux /opt/_internal /opt/_internal
 COPY --from=manylinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux_2_31/riscv64/Dockerfile
+++ b/manylinux_2_31/riscv64/Dockerfile
@@ -107,8 +107,6 @@ ENV RISCV64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/riscv64-unknown-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -117,12 +115,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -132,34 +124,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 
 
 RUN mkdir -p /opt/python
-
-RUN cd /tmp && \
-    VERS=3.7.17 && PREFIX=/opt/python/cp37-cp37m && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=riscv64-unknown-linux-gnu --target=riscv64-unknown-linux-gnu --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-
-RUN cd /tmp && \
-    VERS=3.8.20 && PREFIX=/opt/python/cp38-cp38 && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=riscv64-unknown-linux-gnu --target=riscv64-unknown-linux-gnu --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 RUN cd /tmp && \
     VERS=3.9.25 && PREFIX=/opt/python/cp39-cp39 && \
@@ -244,9 +208,9 @@ RUN cd /tmp && \
     find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
     # We do not need precompiled .pyc and .pyo files.
     find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux_2_36/loongarch64/Dockerfile
+++ b/manylinux_2_36/loongarch64/Dockerfile
@@ -104,8 +104,6 @@ ENV LOONGARCH64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/loongarch64-unknown-linux-gnu
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -114,12 +112,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -129,40 +121,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 
 
 RUN mkdir -p /opt/python
-
-RUN cd /tmp && \
-    VERS=3.7.17 && PREFIX=/opt/python/cp37-cp37m && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub' && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess' && \
-    curl -sL https://github.com/astral-sh/python-build-standalone/raw/8138f8f7337d95bd098b398d368d4763861f2395/cpython-unix/patch-configure-add-loongarch-triplet.patch | patch -p1 && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=loongarch64-unknown-linux-gnu --target=loongarch64-unknown-linux-gnu --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-
-RUN cd /tmp && \
-    VERS=3.8.20 && PREFIX=/opt/python/cp38-cp38 && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub' && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess' && \
-    curl -sL https://github.com/astral-sh/python-build-standalone/raw/8138f8f7337d95bd098b398d368d4763861f2395/cpython-unix/patch-configure-add-loongarch-triplet.patch | patch -p1 && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=loongarch64-unknown-linux-gnu --target=loongarch64-unknown-linux-gnu --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-gnu --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 RUN cd /tmp && \
     VERS=3.9.25 && PREFIX=/opt/python/cp39-cp39 && \
@@ -250,9 +208,9 @@ RUN cd /tmp && \
     find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
     # We do not need precompiled .pyc and .pyo files.
     find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/manylinux_2_39/riscv64/Dockerfile
+++ b/manylinux_2_39/riscv64/Dockerfile
@@ -108,8 +108,6 @@ ENV RISCV64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/usr/riscv64-unknown-linux-gnu/
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -118,12 +116,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -134,9 +126,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=manylinux /opt/_internal /opt/_internal
 COPY --from=manylinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/musllinux_1_2/aarch64/Dockerfile
+++ b/musllinux_1_2/aarch64/Dockerfile
@@ -24,8 +24,6 @@ RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -34,12 +32,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -50,9 +42,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=musllinux /opt/_internal /opt/_internal
 COPY --from=musllinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/musllinux_1_2/armv7l/Dockerfile
+++ b/musllinux_1_2/armv7l/Dockerfile
@@ -24,8 +24,6 @@ ENV ARMV7_UNKNOWN_LINUX_MUSLEABIHF_OPENSSL_DIR=/usr/armv7-unknown-linux-musleabi
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -34,12 +32,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -49,36 +41,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 
 
 RUN mkdir -p /opt/python
-
-RUN cd /tmp && \
-    VERS=3.7.17 && PREFIX=/opt/python/cp37-cp37m && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=armv7l-unknown-linux-gnueabihf --target=armv7l-unknown-linux-gnueabihf --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-musl --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    sed -i 's/_PYTHON_HOST_PLATFORM=linux-arm/_PYTHON_HOST_PLATFORM=linux-armv7l/' Makefile && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-
-RUN cd /tmp && \
-    VERS=3.8.20 && PREFIX=/opt/python/cp38-cp38 && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=armv7l-unknown-linux-gnueabihf --target=armv7l-unknown-linux-gnueabihf --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-musl --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    sed -i 's/_PYTHON_HOST_PLATFORM=linux-arm/_PYTHON_HOST_PLATFORM=linux-armv7l/' Makefile && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 RUN cd /tmp && \
     VERS=3.9.25 && PREFIX=/opt/python/cp39-cp39 && \
@@ -169,9 +131,9 @@ RUN cd /tmp && \
     find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
     # We do not need precompiled .pyc and .pyo files.
     find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/musllinux_1_2/i686/Dockerfile
+++ b/musllinux_1_2/i686/Dockerfile
@@ -24,8 +24,6 @@ RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -34,12 +32,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -50,9 +42,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=musllinux /opt/_internal /opt/_internal
 COPY --from=musllinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/musllinux_1_2/loongarch64/Dockerfile
+++ b/musllinux_1_2/loongarch64/Dockerfile
@@ -24,8 +24,6 @@ ENV LOONGARCH64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=/usr/loongarch64-unknown-linux-mu
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -34,12 +32,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -49,40 +41,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 
 
 RUN mkdir -p /opt/python
-
-RUN cd /tmp && \
-    VERS=3.7.17 && PREFIX=/opt/python/cp37-cp37m && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub' && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess' && \
-    curl -sL https://github.com/astral-sh/python-build-standalone/raw/8138f8f7337d95bd098b398d368d4763861f2395/cpython-unix/patch-configure-add-loongarch-triplet.patch | patch -p1 && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=loongarch64-unknown-linux-musl --target=loongarch64-unknown-linux-musl --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-musl --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-
-RUN cd /tmp && \
-    VERS=3.8.20 && PREFIX=/opt/python/cp38-cp38 && \
-    curl -LO https://www.python.org/ftp/python/$VERS/Python-$VERS.tgz && \
-    tar xzf Python-$VERS.tgz && cd Python-$VERS && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub' && \
-    curl -LO 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess' && \
-    curl -sL https://github.com/astral-sh/python-build-standalone/raw/8138f8f7337d95bd098b398d368d4763861f2395/cpython-unix/patch-configure-add-loongarch-triplet.patch | patch -p1 && \
-    ./configure CC=$TARGET_CC AR=$TARGET_AR READELF=$TARGET_READELF --host=loongarch64-unknown-linux-musl --target=loongarch64-unknown-linux-musl --prefix=$PREFIX --disable-shared --with-ensurepip=no --build=$(uname -m)-linux-musl --disable-ipv6 ac_cv_have_long_long_format=yes ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no && \
-    make -j4 && make -j4 install && \
-    cd /tmp && rm -rf Python-$VERS.tgz Python-$VERS $PREFIX/share && \
-    # we don't need libpython*.a, and they're many megabytes
-    find $PREFIX -name '*.a' -print0 | xargs -0 rm -f && \
-    # We do not need the Python test suites
-    find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
-    # We do not need precompiled .pyc and .pyo files.
-    find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 RUN cd /tmp && \
     VERS=3.9.25 && PREFIX=/opt/python/cp39-cp39 && \
@@ -170,9 +128,9 @@ RUN cd /tmp && \
     find $PREFIX -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf && \
     # We do not need precompiled .pyc and .pyo files.
     find $PREFIX -type f -a \( -name '*.pyc' -o -name '*.pyo' \) -delete
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \

--- a/musllinux_1_2/x86_64/Dockerfile
+++ b/musllinux_1_2/x86_64/Dockerfile
@@ -24,8 +24,6 @@ RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y \
-    python3.7 python3.7-venv python3.7-dev \
-    python3.8 python3.8-venv python3.8-dev \
     python3.9 python3.9-venv python3.9-dev \
     python3.11 python3.11-venv python3.11-dev \
     python3.12 python3.12-venv python3.12-dev \
@@ -34,12 +32,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3 python3-venv python3-dev python-is-python3
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else export PYPY_ARCH="aarch64"; fi && \
-    mkdir -p /usr/local/pypy/pypy3.7 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.9-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
-    mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -s /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     mkdir -p /usr/local/pypy/pypy3.9 && \
     curl -sqL https://downloads.python.org/pypy/pypy3.9-v7.3.12-$PYPY_ARCH.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.9 --strip-components=1 && \
     ln -s /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.9 && \
@@ -50,9 +42,9 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then export PYPY_ARCH="linux64"; else expor
 COPY --from=musllinux /opt/_internal /opt/_internal
 COPY --from=musllinux /opt/python /opt/python
 
-RUN for VER in 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14; do \
+RUN for VER in 3.9 3.10 3.11 3.12 3.13 3.14; do \
         case $VER in \
-            3.7|3.8|3.9) \
+            3.9) \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "python$VER"; \
                 curl -sS https://bootstrap.pypa.io/pip/$VER/get-pip.py | "pypy$VER"; \
                 ;; \


### PR DESCRIPTION
Remove deadsnakes PPA packages, PyPy binaries, and CPython build targets
for Python 3.7 and 3.8 as they have reached End-of-Life (EOL).
- https://devguide.python.org/versions/